### PR TITLE
Making merge_fields actually optional

### DIFF
--- a/hellosign_sdk/hsclient.py
+++ b/hellosign_sdk/hsclient.py
@@ -1594,7 +1594,8 @@ class HSClient(object):
         data.update(file_urls_payload)
         data.update(signer_roles_payload)
         data.update(ccs_payload)
-        data.update(merge_fields_payload)
+        if (merge_fields is not None):
+            data.update(merge_fields_payload)
         data = HSFormat.strip_none_values(data)
 
         request = self._get_request()


### PR DESCRIPTION
Not including the parameter merge_fields in create_embedded_template_draft results in error about 'merge field has undefined name'. This appears to be caused by the merge fields being added to the parameter list even when it is not provided.
