### PR TITLE
Accept a file-like object for writing the signature req file to (fix …

### DIFF
--- a/hellosign_sdk/hsclient.py
+++ b/hellosign_sdk/hsclient.py
@@ -314,14 +314,16 @@ class HSClient(object):
 
         return request.get(self.SIGNATURE_REQUEST_LIST_URL, parameters=parameters)
 
-    def get_signature_request_file(self, signature_request_id, filename, file_type=None):
+    def get_signature_request_file(self, signature_request_id, path_or_file=None, file_type=None, filename=None):
         ''' Download the PDF copy of the current documents
 
         Args:
 
             signature_request_id (str): Id of the signature request
 
-            filename (str):             Filename to save the PDF file to. This should be a full path.
+            path_or_file (str or file): A writable File-like object or a full path to save the PDF file to.
+
+            filename (str):             [DEPRECATED] Filename to save the PDF file to. This should be a full path.
 
             file_type (str):            Type of file to return. Either "pdf" for a single merged document or "zip" for a collection of individual documents. Defaults to "pdf" if not specified.
 
@@ -333,7 +335,7 @@ class HSClient(object):
         url = self.SIGNATURE_REQUEST_DOWNLOAD_PDF_URL + signature_request_id
         if file_type:
             url += '?file_type=%s' % file_type
-        return request.get_file(url, filename)
+        return request.get_file(url, path_or_file or filename)
 
     def send_signature_request(self, test_mode=False, files=None, file_urls=None, title=None, subject=None, message=None, signing_redirect_url=None, signers=None, cc_email_addresses=None, form_fields_per_document=None, use_text_tags=False, hide_text_tags=False, metadata=None, ux_version=None):
         ''' Creates and sends a new SignatureRequest with the submitted documents

--- a/hellosign_sdk/tests/unit_tests/test_request.py
+++ b/hellosign_sdk/tests/unit_tests/test_request.py
@@ -4,6 +4,7 @@ from hellosign_sdk import HSClient
 from hellosign_sdk.utils import HSRequest, BadRequest
 import tempfile
 import os
+import StringIO
 
 #
 # The MIT License (MIT)
@@ -92,14 +93,20 @@ class Request(TestCase):
         f.close()
         response = request.get_file(url='http://httpbin.org/robots.txt',
                                     headers={'Custom-Header': 'Nothing'},
-                                    filename=temp_filename)
+                                    path_or_file=temp_filename)
         os.unlink(temp_filename)
         self.assertEquals(response, True)
 
         response = request.get_file(url='http://httpbin.org/robots.txt',
                                     headers={'Custom-Header': 'Nothing'},
-                                    filename='')
+                                    path_or_file='')
         self.assertEquals(response, False)
+
+        out = StringIO.StringIO()
+        response = request.get_file(url='http://httpbin.org/robots.txt',
+                                    headers={'Custom-Header': 'Nothing'},
+                                    path_or_file=out)
+        self.assertEquals(response, True)
 
     def test_get_file_https(self):
         request = HSRequest(self.client.auth)
@@ -109,11 +116,17 @@ class Request(TestCase):
 
         response = request.get_file(url='https://httpbin.org/robots.txt',
                                     headers={'Custom-Header': 'Nothing'},
-                                    filename=temp_filename)
+                                    path_or_file=temp_filename)
         os.unlink(temp_filename)
         self.assertEquals(response, True)
 
         response = request.get_file(url='https://httpbin.org/robots.txt',
                                     headers={'Custom-Header': 'Nothing'},
-                                    filename='')
+                                    path_or_file='')
         self.assertEquals(response, False)
+
+        out = StringIO.StringIO()
+        response = request.get_file(url='http://httpbin.org/robots.txt',
+                                    headers={'Custom-Header': 'Nothing'},
+                                    path_or_file=out)
+        self.assertEquals(response, True)


### PR DESCRIPTION
for `HSClient.get_signature_request_file` & `HSRequest.get_file`:
- deprecated the `filename` parameter.
- introduced a new `path_or_file` parameter which accepts with a path to a file
  or a file-like object.
