### PR TITLE
Fail more noisily if no path or file provided to Request.get_file

### DIFF
--- a/hellosign_sdk/utils/request.py
+++ b/hellosign_sdk/utils/request.py
@@ -86,6 +86,9 @@ class HSRequest(object):
         '''
         path_or_file = path_or_file or filename
 
+        if not path_or_file:
+            raise ValueError('Must provide path_or_file argument.')
+
         if self.debug:
             print("GET FILE: %s, headers=%s" % (url, headers))
 


### PR DESCRIPTION
I just spent an hour trying to figure out why get_signature_request_file was returning False.  The problem turned out to be that I wasn't providing either of the path_or_file or filename arguments.  This patch catches that case and raises a ValueError.

This fix is very limited in scope.  I think the better fix would be to let all exceptions bubble up instead of trapping them all in a try/except and returning False.  That way there is more information available to the caller.  I have avoided doing that in my patch because the SDK seems committed to a paradigm of True for success, False for failure.  If you're open to revisiting that, let's do it.
