### PR TITLE
Fixes tests when running in Python 2.7 and 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ if event_data['event']['event_type'] == 'signature_request_sent':
 
 ## Tests
 
+### Setup
+```
+# Create a new virtual environment that uses Python 3
+mkvirtualenv hellosign-py3 -p `which python3` --no-site-packages
+workon hellosign-py3
+
+# Install the required dependencies
+pip install -r test_requirements.txt
+```
+
+### Running Tests
 You can run the test suite by executing the following commands after you cloned the repo:
 Note that it requires to have a HelloSign account, with at least one template and one api app.
 
@@ -242,7 +253,7 @@ cp tests/test_helper.sample.py tests/test_helper.py
 HELLOSIGN_API_KEY='YOUR API KEY'
 HELLOSIGN_API_CLIENT_ID='YOUR APP CLIENT ID'
 HELLOSIGN_API_CLIENT_SECRET='YOUR APP CLIENT SECRET'
-nosetests --with-coverage --cover-package=hellosign_sdk --include=hellosign_sdk/tests/unit_tests/* --include=hellosign_sdk/tests/functional_tests/*
+nosetests --with-coverage --cover-package=hellosign_sdk hellosign_sdk.tests.unit_tests hellosign_sdk.tests.functional_tests
 ```
 
 ## Additional notes

--- a/README.md
+++ b/README.md
@@ -233,11 +233,7 @@ if event_data['event']['event_type'] == 'signature_request_sent':
 
 ### Setup
 ```
-# Create a new virtual environment that uses Python 3
-mkvirtualenv hellosign-py3 -p `which python3` --no-site-packages
-workon hellosign-py3
-
-# Install the required dependencies
+# Preferably in a virtualenv, install the required dependencies
 pip install -r test_requirements.txt
 ```
 

--- a/hellosign_sdk/tests/functional_tests/__init__.py
+++ b/hellosign_sdk/tests/functional_tests/__init__.py
@@ -1,3 +1,3 @@
-from base_test_case import BaseTestCase
+from .base_test_case import BaseTestCase
 
 __all__ = [BaseTestCase]

--- a/hellosign_sdk/tests/functional_tests/base_test_case.py
+++ b/hellosign_sdk/tests/functional_tests/base_test_case.py
@@ -30,8 +30,6 @@ from hellosign_sdk.tests import test_helper
 class BaseTestCase(TestCase):
     ''' Base for all test cases '''
 
-    warned = False
-
     def setUp(self):
         params = {
             'api_key': test_helper.api_key
@@ -40,29 +38,17 @@ class BaseTestCase(TestCase):
             params['env'] = test_helper.env
         except AttributeError:
             params['env'] = 'production'
+        try:
+            ok_to_run_functional_tests = test_helper.ok_to_run_functional_tests
+        except AttributeError:
+            ok_to_run_functional_tests = False
         self.client = HSClient(**params)
         self.client_id = test_helper.client_id
         self.client_secret = test_helper.client_secret
 
-        if params['env'] == 'production' and not BaseTestCase.warned:
-            BaseTestCase.warned = True
-            print("\n\n")
-            print(" ==================================================================")
-            print(" = WARNING: We advise against running the tests against your      =")
-            print(" = personal account as they perform destructive actions.          =")
-            print(" ==================================================================")
-            while True:
-                resp = raw_input(' > Continue (type yes or hit Ctrl+C to exit)?')
-                if resp == 'yes':
-                    # Continue to tests
-                    break
-                elif resp == 'no':
-                    # Stop here
-                    import sys
-                    sys.exit()
-                else:
-                    # Ask question again
-                    pass 
-            print
-
-        print
+        if params['env'] == 'production' and not ok_to_run_functional_tests:
+            raise Exception(
+                'We advise against running the tests against your personal '
+                'account as they perform destructive actions. Please set '
+                "ok_to_run_functional_tests=True in test_helper.py"
+            )

--- a/hellosign_sdk/tests/functional_tests/base_test_case.py
+++ b/hellosign_sdk/tests/functional_tests/base_test_case.py
@@ -39,16 +39,16 @@ class BaseTestCase(TestCase):
         except AttributeError:
             params['env'] = 'production'
         try:
-            ok_to_run_functional_tests = test_helper.ok_to_run_functional_tests
+            should_run_functional_tests = test_helper.should_run_functional_tests
         except AttributeError:
-            ok_to_run_functional_tests = False
+            should_run_functional_tests = False
         self.client = HSClient(**params)
         self.client_id = test_helper.client_id
         self.client_secret = test_helper.client_secret
 
-        if params['env'] == 'production' and not ok_to_run_functional_tests:
+        if params['env'] == 'production' and not should_run_functional_tests:
             raise Exception(
                 'We advise against running the tests against your personal '
                 'account as they perform destructive actions. Please set '
-                "ok_to_run_functional_tests=True in test_helper.py"
+                "should_run_functional_tests=True in test_helper.py"
             )

--- a/hellosign_sdk/tests/functional_tests/test_requests.py
+++ b/hellosign_sdk/tests/functional_tests/test_requests.py
@@ -93,4 +93,4 @@ class TestRequests(BaseTestCase):
             int(parts[1])
         except ValueError:
             self.fail('Invalid version number')
-        self.assertEquals(parts[2], '0')
+        self.assertEquals(parts[2], '5')

--- a/hellosign_sdk/tests/functional_tests/test_team.py
+++ b/hellosign_sdk/tests/functional_tests/test_team.py
@@ -59,7 +59,7 @@ class TestTeam(BaseTestCase):
         ''' Test adding a new team member '''
 
         team = self.client.get_team_info()
-        num_members = len(team.accounts)
+        num_invited_accounts = len(team.invited_accounts)
 
         # Invalid
         try:
@@ -76,7 +76,7 @@ class TestTeam(BaseTestCase):
         # Valid
         result = self.client.add_team_member(email_address="py-sdk-test-%s@example.com" % time())
         self.assertTrue(isinstance(result, Team))
-        self.assertEquals(len(result.accounts), num_members + 1)
+        self.assertEquals(len(result.invited_accounts), num_invited_accounts + 1)
 
     def test_remove_team_member(self):
         ''' Test removing a team member '''

--- a/hellosign_sdk/tests/unit_tests/test_hsformat.py
+++ b/hellosign_sdk/tests/unit_tests/test_hsformat.py
@@ -40,7 +40,7 @@ class TestHSFormat(TestCase):
 
         result = HSFormat.format_file_params(input_params)
 
-        keys = result.keys()
+        keys = list(result.keys())
 
         attribute = hasattr(result[keys[0]], 'read') #check if file (can be read)
 

--- a/hellosign_sdk/tests/unit_tests/test_request.py
+++ b/hellosign_sdk/tests/unit_tests/test_request.py
@@ -4,7 +4,7 @@ from hellosign_sdk import HSClient
 from hellosign_sdk.utils import HSRequest, BadRequest
 import tempfile
 import os
-import StringIO
+from io import BytesIO
 
 #
 # The MIT License (MIT)
@@ -102,7 +102,7 @@ class Request(TestCase):
                                     path_or_file='')
         self.assertEquals(response, False)
 
-        out = StringIO.StringIO()
+        out = BytesIO()
         response = request.get_file(url='http://httpbin.org/robots.txt',
                                     headers={'Custom-Header': 'Nothing'},
                                     path_or_file=out)
@@ -125,7 +125,7 @@ class Request(TestCase):
                                     path_or_file='')
         self.assertEquals(response, False)
 
-        out = StringIO.StringIO()
+        out = BytesIO()
         response = request.get_file(url='http://httpbin.org/robots.txt',
                                     headers={'Custom-Header': 'Nothing'},
                                     path_or_file=out)


### PR DESCRIPTION
When running tests in Python 3, many of the tests fail. This PR updates tests so they all pass when running in Python 3 while maintaining 2.7 compatibility. Note that no changes were necessary in the library code, only the testing code was broken.

[Updated to reflect Python 2.7 compatibility]