### PR TITLE
Fix improper use of Requests for file upload

### DIFF
--- a/hellosign_sdk/utils/hsformat.py
+++ b/hellosign_sdk/utils/hsformat.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 #
 
+import os
 
 class HSFormat(object):
     ''' Authentication object using HelloSign's access token '''
@@ -42,10 +43,13 @@ class HSFormat(object):
         '''
             Utility method for formatting file parameters for transmission
         '''
-        files_payload = {}
+        files_payload = []
         if files:
             for idx, filename in enumerate(files):
-                files_payload["file[" + str(idx) + "]"] = open(filename, 'rb')
+                files_payload.append((
+                    'file[%s]' % idx,
+                     (os.path.basename(filename), open(filename, 'rb'))
+                ))
         return files_payload
 
     @staticmethod


### PR DESCRIPTION
The data structure prepared by `format_file_params` is supposed to be a list of tuples with a certain structure, not the dict one created currently. See https://github.com/HelloFax/hellosign-python-sdk/issues/34 for details of the issue being addressed here.