### PR TITLE
fix regression in get_signature_request_file

### DIFF
--- a/hellosign_sdk/hsclient.py
+++ b/hellosign_sdk/hsclient.py
@@ -341,14 +341,16 @@ class HSClient(object):
         '''
         request = self._get_request()
         url = self.SIGNATURE_REQUEST_DOWNLOAD_PDF_URL + signature_request_id
-        if file_type:
-            url += '?file_type=%s' % file_type
-            return request.get_file(url, path_or_file or filename)
 
         if response_type == 'url':
             url += '?get_url=1'
         elif response_type == 'data_uri':
             url += '?get_data_uri=1'
+        else:
+            if file_type:
+                url += '?file_type=%s' % file_type
+            return request.get_file(url, path_or_file or filename)
+
         return request.get(url)
 
     def send_signature_request(self, test_mode=False, client_id=None, files=None, file_urls=None,


### PR DESCRIPTION
Had the following line in our codebase, which downloaded a completed signature request to a temporary file:
```
client.get_signature_request_file(request.hellosign_id, tf)
```

After updating to the latest release, this line raised a `JSONDecodeError`.

```
File "/app/.heroku/python/lib/python3.8/site-packages/hellosign_sdk/hsclient.py" in get_signature_request_file
  352.         return request.get(url)

File "/app/.heroku/python/lib/python3.8/site-packages/hellosign_sdk/utils/request.py" in get
  141.         json_response = self._process_json_response(response)

File "/app/.heroku/python/lib/python3.8/site-packages/hellosign_sdk/utils/request.py" in _process_json_response
  224.         json_response = self._get_json_response(response)

File "/app/.heroku/python/lib/python3.8/site-packages/hellosign_sdk/utils/request.py" in _get_json_response
  207.                 raise e

File "/app/.heroku/python/lib/python3.8/site-packages/hellosign_sdk/utils/request.py" in _get_json_response
  203.                     return json.loads(text)

File "/app/.heroku/python/lib/python3.8/json/__init__.py" in loads
  357.         return _default_decoder.decode(s)

File "/app/.heroku/python/lib/python3.8/json/decoder.py" in decode
  337.         obj, end = self.raw_decode(s, idx=_w(s, 0).end())

File "/app/.heroku/python/lib/python3.8/json/decoder.py" in raw_decode
  355.             raise JSONDecodeError("Expecting value", s, err.value) from None
```

It appears that, given no arguments, `get_signature_request_file` expects a JSON response from the API, but is getting a file instead. This PR fixes the issue and attempts to follow the behavior outlined in the docstring.