### PR TITLE
Rename request parameter per the api documentation

### DIFF
--- a/hellosign_sdk/hsclient.py
+++ b/hellosign_sdk/hsclient.py
@@ -984,6 +984,7 @@ class HSClient(object):
             A Template object
 
         '''
+        files_payload = HSFormat.format_file_params(file)
         request = self._get_request()
         return request.post(self.TEMPLATE_UPDATE_FILES_URL + template_id, data={
             "file": file,
@@ -992,7 +993,7 @@ class HSClient(object):
             "message": message,
             "test_mode": self._boolean(test_mode),
             "client_id": client_id
-        })
+        }, files=files_payload)
 
     def create_embedded_template_draft(self, client_id, signer_roles, test_mode=False,
             files=None, file_urls=None, title=None, subject=None, message=None,

--- a/hellosign_sdk/hsclient.py
+++ b/hellosign_sdk/hsclient.py
@@ -958,7 +958,7 @@ class HSClient(object):
             url += '?get_data_uri=1'
         return request.get(url)
 
-    def update_template_files(self, template_id, files=None, file_urls=None,
+    def update_template_files(self, template_id, files=None, file_url=None,
             subject=None, message=None, client_id=None, test_mode=False):
         ''' Overlays a new file with the overlay of an existing template.
 
@@ -987,7 +987,7 @@ class HSClient(object):
         request = self._get_request()
         return request.post(self.TEMPLATE_UPDATE_FILES_URL + template_id, data={
             "files": files,
-            "file_urls": file_urls,
+            "file_url": file_url,
             "subject": subject,
             "message": message,
             "test_mode": self._boolean(test_mode),

--- a/hellosign_sdk/hsclient.py
+++ b/hellosign_sdk/hsclient.py
@@ -958,7 +958,7 @@ class HSClient(object):
             url += '?get_data_uri=1'
         return request.get(url)
 
-    def update_template_files(self, template_id, files=None, file_url=None,
+    def update_template_files(self, template_id, file=None, file_url=None,
             subject=None, message=None, client_id=None, test_mode=False):
         ''' Overlays a new file with the overlay of an existing template.
 
@@ -986,7 +986,7 @@ class HSClient(object):
         '''
         request = self._get_request()
         return request.post(self.TEMPLATE_UPDATE_FILES_URL + template_id, data={
-            "files": files,
+            "file": file,
             "file_url": file_url,
             "subject": subject,
             "message": message,

--- a/hellosign_sdk/utils/request.py
+++ b/hellosign_sdk/utils/request.py
@@ -258,7 +258,10 @@ class HSRequest(object):
                 raise err_cls("%s error: %s" % (response.status_code, json_response["error"]["error_msg"]), response.status_code)
             # This is to catch error when we post get oauth data
             except TypeError:
-                raise err_cls("%s error: %s" % (response.status_code, json_response["error_description"]), response.status_code)
+                try:
+                    raise err_cls("%s error: %s" % (response.status_code, json_response["error_description"]), response.status_code)
+                except TypeError:
+                    raise err_cls("%s error" % response.status_code)
 
         # Return True if everything is OK
         return True


### PR DESCRIPTION
Rename file_urls request parameter to file_url. Currently the request parameter for file_urls is not valid per the api documentation.

https://app.hellosign.com/api/reference#update_template_files